### PR TITLE
Join fails on complex polymorphic associations

### DIFF
--- a/test/polymorphic_test.rb
+++ b/test/polymorphic_test.rb
@@ -1,0 +1,73 @@
+require File.expand_path("../test_helper", __FILE__)
+
+ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS accounts"
+ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS shouts"
+ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS text_shouts"
+ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS picture_shouts"
+
+
+ActiveRecord::Base.connection.create_table :accounts do |t|
+end
+
+ActiveRecord::Base.connection.create_table :shouts do |t|
+  t.references :account
+  t.string :content_type
+  t.string :content_id
+end
+
+ActiveRecord::Base.connection.create_table :text_shouts do |t|
+  t.text :text
+end
+
+ActiveRecord::Base.connection.create_table :picture_shouts do |t|
+  t.text :url
+end
+
+class Shout < ActiveRecord::Base
+  belongs_to :account
+  belongs_to :content, :polymorphic => true
+end
+
+class TextShout < ActiveRecord::Base
+  validates :text, :presence => true
+end
+
+class PictureShout < ActiveRecord::Base
+  validates :url, :presence => true
+end
+
+class Account < ActiveRecord::Base
+
+  has_many :shouts
+  has_many :text_shouts, :through => :shouts, :source => :content, :source_type => TextShout
+  has_many :picture_shouts, :through => :shouts, :source => :content, :source_type => PictureShout
+
+  include SearchCop
+
+  search_scope :search do
+    attributes :text_shout => "text_shouts.text"
+    attributes :picture_shout => "picture_shouts.url"
+  end
+end
+
+class PolymorphicTest < SearchCop::TestCase
+  def teardown
+    Account.delete_all
+    Shout.delete_all
+    TextShout.delete_all
+    PictureShout.delete_all
+  end
+
+  def test_polymorphic_associations
+    account = Account.create!
+
+    text_shout = TextShout.new(:text => "Hello")
+    picture_shout = PictureShout.new(:url => "some url")
+
+    account.shouts.create!(:content => text_shout)
+    account.shouts.create!(:content => picture_shout)
+
+    assert_includes Account.search("Hello"), account
+    assert_includes Account.search("some"), account
+  end
+end


### PR DESCRIPTION
Get ready, cause this ones a doozy. I have a polymorphic association that I'm trying to do searches on. I've written a test case that shows the incorrect behavior `polymorphic_test.rb`. 

The issue is the SQL generated is wrong. The query builder generates this statement:

``` sql
SELECT "accounts"."id"        AS t0_r0, 
       "text_shouts"."id"     AS t1_r0, 
       "text_shouts"."text"   AS t1_r1, 
       "picture_shouts"."id"  AS t2_r0, 
       "picture_shouts"."url" AS t2_r1 
FROM   "accounts" 
       LEFT OUTER JOIN "shouts" 
                    ON "shouts"."account_id" = "accounts"."id" 
                       AND "shouts"."content_type" = 'TextShout' 
       LEFT OUTER JOIN "text_shouts" 
                    ON "text_shouts"."id" = "shouts"."content_id" 
       LEFT OUTER JOIN "shouts" "shouts_accounts_join" 
                    ON "shouts_accounts_join"."account_id" = "accounts"."id" 
                       AND "shouts"."content_type" = 'PictureShout' 
       LEFT OUTER JOIN "picture_shouts" 
                    ON "picture_shouts"."id" = 
                       "shouts_accounts_join"."content_id" 
WHERE  (( "text_shouts"."text" LIKE '%some%' 
           OR "picture_shouts"."url" LIKE '%some%' )) 
```

Notice the second join to the `shouts` table for `PictureShout`. It uses the correct aliased table `shouts_accounts_join` for the `id` comparison, but uses the original table name `shouts` instead of the alias for the second comparison `content_type`. 

Digging through the source, I feel like this may be a bug in arel itself, but I'm not sure. Any help would be appreciated! Sorry for such a complex issue, I don't know how to show it more simply.
