### PR TITLE
QueryBuilder fails when trying to parse quotes

### DIFF
--- a/lib/search_cop_grammar.rb
+++ b/lib/search_cop_grammar.rb
@@ -1,4 +1,3 @@
-
 require "search_cop_grammar/attributes"
 require "search_cop_grammar/nodes"
 
@@ -83,8 +82,19 @@ module SearchCopGrammar
   end
 
   class AnywhereExpression < BaseNode
+    def sanitized_text_value
+      text_value.gsub(/^'|'$/, "").gsub(/^"|"$/, "")
+    end
+
     def evaluate
-      queries = query_info.scope.reflection.default_attributes.keys.collect { |key| collection_for key }.select { |collection| collection.compatible? text_value }.collect { |collection| collection.matches text_value }
+      queries = query_info
+                .scope
+                .reflection
+                .default_attributes
+                .keys
+                .collect { |key| collection_for key }
+                .select { |collection| collection.compatible? sanitized_text_value }
+                .collect { |collection| collection.matches sanitized_text_value }
 
       raise SearchCop::NoSearchableAttributes if queries.empty?
 
@@ -130,4 +140,3 @@ module SearchCopGrammar
 
   class Value < BaseNode; end
 end
-

--- a/lib/search_cop_grammar.treetop
+++ b/lib/search_cop_grammar.treetop
@@ -37,7 +37,7 @@ grammar SearchCopGrammar
   end
 
   rule anywhere_expression
-    ("'" ([^\']* <AnywhereExpression>) "'") / ('"' ([^\"]* <AnywhereExpression>) '"') / [^\s()]+ <AnywhereExpression>
+    ("'" (.* <AnywhereExpression>) "'") / ('"' (.* <AnywhereExpression>) '"') / [^\s()]+ <AnywhereExpression>
   end
 
   rule simple_column

--- a/test/search_cop_test.rb
+++ b/test/search_cop_test.rb
@@ -1,4 +1,3 @@
-
 require File.expand_path("../test_helper", __FILE__)
 
 class SearchCopTest < SearchCop::TestCase
@@ -131,5 +130,13 @@ class SearchCopTest < SearchCop::TestCase
   def test_blank
     assert_equal Product.all, Product.search("")
   end
-end
 
+  def test_quotes
+    product = create(:product, :title => "Title")
+
+    results = Product.search('"Title"')
+
+    assert_equal 1, results.count
+    assert_includes results, product
+  end
+end


### PR DESCRIPTION
I tried working it out, but I could use some direction. 

https://github.com/mrkamel/search_cop/blob/master/lib/search_cop_grammar.treetop#L47-L49 seems wrong to me. Is that saying that a value is something like `'''''` or `"""` but not `"Text"`? I don't see how that regex could ever match something between quotes. I also am not good at parsing grammars :). 

Let me know what should happen and I'm happy to keep trying.