### PR TITLE
Add 'type' attribute, add 'in' operator

### DIFF
--- a/lib/search_cop/grammar_parser.rb
+++ b/lib/search_cop/grammar_parser.rb
@@ -23,7 +23,7 @@ module SearchCop
 
     def convert_in_operator_to_or_chain(string)
       string.scan(In_Operator_Regex).each do |in_exp, param, list|
-          list.split(",").map(&:strip).map do |value|
+          subquery = list.split(",").map(&:strip).map do |value|
              "#{param} = #{value}"
           end.join(" or ")
 

--- a/lib/search_cop/grammar_parser.rb
+++ b/lib/search_cop/grammar_parser.rb
@@ -8,7 +8,7 @@ module SearchCop
   class GrammarParser
     attr_reader :query_info
 
-    In_Operator_Regex = /(([a-zA-Z]*) in \(([a-zA-Z0-9|, ]*)\))/
+    In_Operator_Regex = /(([a-zA-Z_]*) in \(([a-zA-Z0-9_|, ]*)\))/
 
     def initialize(query_info)
       @query_info = query_info

--- a/lib/search_cop/grammar_parser.rb
+++ b/lib/search_cop/grammar_parser.rb
@@ -8,7 +8,7 @@ module SearchCop
   class GrammarParser
     attr_reader :query_info
 
-    In_Operator_Regex = /(([a-zA-Z]*) in \(([a-zA-Z|, ]*)\))/
+    In_Operator_Regex = /(([a-zA-Z]*) in \(([a-zA-Z0-9|, ]*)\))/
 
     def initialize(query_info)
       @query_info = query_info
@@ -27,7 +27,7 @@ module SearchCop
              "#{param} = #{value}"
           end.join(" or ")
 
-          string = string.sub(in_exp, subquery)
+          string = string.sub(in_exp, "(#{subquery})")
       end 
       string
     end

--- a/lib/search_cop/grammar_parser.rb
+++ b/lib/search_cop/grammar_parser.rb
@@ -8,14 +8,28 @@ module SearchCop
   class GrammarParser
     attr_reader :query_info
 
+    In_Operator_Regex = /(([a-zA-Z]*) in \(([a-zA-Z|, ]*)\))/
+
     def initialize(query_info)
       @query_info = query_info
     end
 
     def parse(string)
+      string = convert_in_operator_to_or_chain string
       node = SearchCopGrammarParser.new.parse(string) || raise(ParseError)
       node.query_info = query_info
       node.evaluate
+    end
+
+    def convert_in_operator_to_or_chain(string)
+      string.scan(In_Operator_Regex).each do |in_exp, param, list|
+          list.split(",").map(&:strip).map do |value|
+             "#{param} = #{value}"
+          end.join(" or ")
+
+          string = string.sub(in_exp, subquery)
+      end 
+      string
     end
   end
 end

--- a/lib/search_cop/search_scope.rb
+++ b/lib/search_cop/search_scope.rb
@@ -1,12 +1,13 @@
 
 module SearchCop
   class Reflection
-    attr_accessor :attributes, :options, :aliases, :scope
+    attr_accessor :attributes, :options, :aliases, :scope, :type
 
     def initialize
       self.attributes = {}
       self.options = {}
       self.aliases = {}
+      self.type = {}
     end
 
     def default_attributes
@@ -34,6 +35,10 @@ module SearchCop
 
     def options(key, options = {})
       reflection.options[key.to_s] = (reflection.options[key.to_s] || {}).merge(options)
+    end
+
+    def type(key, type)
+      reflection.type[key.to_s] = reflection.type[key.to_s] || type
     end
 
     def aliases(hash)

--- a/lib/search_cop/search_scope.rb
+++ b/lib/search_cop/search_scope.rb
@@ -15,7 +15,9 @@ module SearchCop
       keys = attributes.keys.reject { |key| options[key] && options[key][:default] == false } if keys.empty?
       keys = keys.to_set
 
-      attributes.select { |key, value| keys.include? key }
+      attributes.select do |key, value|
+        keys.include?(key) && !type.keys.include?(key)
+      end
     end
   end
 

--- a/lib/search_cop/version.rb
+++ b/lib/search_cop/version.rb
@@ -1,3 +1,3 @@
 module SearchCop
-  VERSION = "1.0.6"
+  VERSION = "1.0.7"
 end

--- a/lib/search_cop/version.rb
+++ b/lib/search_cop/version.rb
@@ -1,3 +1,3 @@
 module SearchCop
-  VERSION = "1.0.7"
+  VERSION = "1.0.9"
 end

--- a/lib/search_cop/version.rb
+++ b/lib/search_cop/version.rb
@@ -1,3 +1,3 @@
 module SearchCop
-  VERSION = "1.0.9"
+  VERSION = "1.0.7"
 end

--- a/lib/search_cop/version.rb
+++ b/lib/search_cop/version.rb
@@ -1,3 +1,3 @@
 module SearchCop
-  VERSION = "1.0.7"
+  VERSION = "1.0.8"
 end

--- a/lib/search_cop/version.rb
+++ b/lib/search_cop/version.rb
@@ -1,3 +1,3 @@
 module SearchCop
-  VERSION = "1.0.8"
+  VERSION = "1.0.7"
 end

--- a/lib/search_cop_grammar/attributes.rb
+++ b/lib/search_cop_grammar/attributes.rb
@@ -51,6 +51,10 @@ module SearchCopGrammar
         query_info.scope.reflection.options[key]
       end
 
+      def type
+        query_info.scope.reflection.type[key]
+      end
+
       def attributes
         @attributes ||= query_info.scope.reflection.attributes[key].collect { |attribute_definition| attribute_for attribute_definition }
       end
@@ -84,9 +88,12 @@ module SearchCopGrammar
         table, column = attribute_definition.split(".")
         klass = klass_for(table)
 
-        raise(SearchCop::UnknownAttribute, "Unknown attribute #{attribute_definition}") unless klass.columns_hash[column]
+        type_ = type || begin
+          raise(SearchCop::UnknownAttribute, "Unknown attribute #{attribute_definition}") unless klass.columns_hash[column]
+          klass.columns_hash[column].type
+        end
 
-        Attributes.const_get(klass.columns_hash[column].type.to_s.classify).new(klass, alias_for(table), column, options)
+        Attributes.const_get(type_.to_s.classify).new(klass, alias_for(table), column, options)
       end
     end
 

--- a/lib/search_cop_grammar/attributes.rb
+++ b/lib/search_cop_grammar/attributes.rb
@@ -87,7 +87,7 @@ module SearchCopGrammar
 
         table, column = attribute_definition.split(".")
         klass = klass_for(table)
-
+        puts type || column
         type_ = type || begin
           raise(SearchCop::UnknownAttribute, "Unknown attribute #{attribute_definition}") unless klass.columns_hash[column]
           klass.columns_hash[column].type

--- a/lib/search_cop_grammar/attributes.rb
+++ b/lib/search_cop_grammar/attributes.rb
@@ -87,7 +87,7 @@ module SearchCopGrammar
 
         table, column = attribute_definition.split(".")
         klass = klass_for(table)
-        puts type || column
+
         type_ = type || begin
           raise(SearchCop::UnknownAttribute, "Unknown attribute #{attribute_definition}") unless klass.columns_hash[column]
           klass.columns_hash[column].type

--- a/test/search_cop_test.rb
+++ b/test/search_cop_test.rb
@@ -91,6 +91,8 @@ class SearchCopTest < SearchCop::TestCase
     refute_includes results, product3
   end
 
+
+
   def test_custom_default_disabled
     product1 = create(:product, :brand => "Expected")
     product2 = create(:product, :notice => "Expected")
@@ -118,7 +120,7 @@ class SearchCopTest < SearchCop::TestCase
   def test_default_attributes_fales
     with_options(Product.search_scopes[:search], :title, :default => false) do
       with_options(Product.search_scopes[:search], :description, :default => false) do
-        assert_equal Product.search_scopes[:search].reflection.attributes.keys - ["title", "description"], Product.search_scopes[:search].reflection.default_attributes.keys
+        assert_equal Product.search_scopes[:search].reflection.attributes.keys - ["title", "description", "test"], Product.search_scopes[:search].reflection.default_attributes.keys
       end
     end
   end

--- a/test/search_cop_test.rb
+++ b/test/search_cop_test.rb
@@ -91,6 +91,14 @@ class SearchCopTest < SearchCop::TestCase
     refute_includes results, product3
   end
 
+  def test_types
+    product1 = create(:product, :title => "Expected")
+
+    assert Product.search("test = test")
+
+    product2 = create(:product_test, :title => "Expected")
+    assert_raises (SearchCop::UnknownAttribute) {ProductTest.search("test2 = test")}
+  end
 
 
   def test_custom_default_disabled

--- a/test/search_cop_test.rb
+++ b/test/search_cop_test.rb
@@ -92,11 +92,7 @@ class SearchCopTest < SearchCop::TestCase
   end
 
   def test_types
-    product1 = create(:product, :title => "Expected")
-
     assert Product.search("test = test")
-
-    product2 = create(:product_test, :title => "Expected")
     assert_raises (SearchCop::UnknownAttribute) {ProductTest.search("test2 = test")}
   end
 

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -90,5 +90,12 @@ class StringTest < SearchCop::TestCase
     assert_includes Product.search("title <= 'Title B'"), product
     refute_includes Product.search("title <= 'Title A'"), product
   end
+
+  def test_in
+    product = create(:product, :title => "Expected")
+
+    assert_includes Product.search("title in (Expected, Rejected)"), product
+    refute_includes Product.search("title in (Rejected)"), product
+  end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,8 +72,19 @@ class Product < ActiveRecord::Base
   belongs_to :user
 end
 
+class ProductTest < Product
+  include SearchCop
+
+  search_scope :search do
+    attributes :test2
+  end
+end
+
 FactoryGirl.define do
   factory :product do
+  end
+
+  factory :product_test do
   end
 
   factory :comment do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ class Product < ActiveRecord::Base
   include SearchCop
 
   search_scope :search do
-    attributes :title, :description, :brand, :notice, :stock, :price, :created_at, :created_on, :available
+    attributes :title, :description, :brand, :notice, :stock, :price, :created_at, :created_on, :available, :test
     attributes :comment => ["comments.title", "comments.message"], :user => ["users.username", "users_products.username"]
     attributes :primary => [:title, :description]
 
@@ -52,6 +52,8 @@ class Product < ActiveRecord::Base
     if DATABASE == "postgres"
       options :title, :dictionary => "english"
     end
+
+    type :test, :float
   end
 
   search_scope :user_search do


### PR DESCRIPTION
type attribute for columns that do not exist in database but get created in query,
in operator for convenient search -> shortcut for or-chaining