### PR TITLE
add type attribute

### DIFF
--- a/lib/search_cop/search_scope.rb
+++ b/lib/search_cop/search_scope.rb
@@ -1,12 +1,13 @@
 
 module SearchCop
   class Reflection
-    attr_accessor :attributes, :options, :aliases, :scope
+    attr_accessor :attributes, :options, :aliases, :scope, :type
 
     def initialize
       self.attributes = {}
       self.options = {}
       self.aliases = {}
+      self.type = {}
     end
 
     def default_attributes
@@ -14,7 +15,9 @@ module SearchCop
       keys = attributes.keys.reject { |key| options[key] && options[key][:default] == false } if keys.empty?
       keys = keys.to_set
 
-      attributes.select { |key, value| keys.include? key }
+      attributes.select do |key, value|
+        keys.include?(key) && !type.keys.include?(key)
+      end
     end
   end
 
@@ -44,6 +47,10 @@ module SearchCop
 
     def scope(&block)
       reflection.scope = block
+    end
+
+    def type(key, type)
+      reflection.type[key.to_s] ||= type
     end
 
     private

--- a/test/search_cop_test.rb
+++ b/test/search_cop_test.rb
@@ -101,6 +101,10 @@ class SearchCopTest < SearchCop::TestCase
     refute_includes results, product2
   end
 
+  def test_types
+    assert Product.search("aggregated_column = 30.3")
+  end
+
   def test_count
     create_list :product, 2, :title => "Expected"
 
@@ -118,7 +122,7 @@ class SearchCopTest < SearchCop::TestCase
   def test_default_attributes_fales
     with_options(Product.search_scopes[:search], :title, :default => false) do
       with_options(Product.search_scopes[:search], :description, :default => false) do
-        assert_equal Product.search_scopes[:search].reflection.attributes.keys - ["title", "description"], Product.search_scopes[:search].reflection.default_attributes.keys
+        assert_equal Product.search_scopes[:search].reflection.attributes.keys - ["title", "description", "aggregated_column"], Product.search_scopes[:search].reflection.default_attributes.keys
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ class Product < ActiveRecord::Base
   include SearchCop
 
   search_scope :search do
-    attributes :title, :description, :brand, :notice, :stock, :price, :created_at, :created_on, :available
+    attributes :title, :description, :brand, :notice, :stock, :price, :created_at, :created_on, :available, :aggregated_column
     attributes :comment => ["comments.title", "comments.message"], :user => ["users.username", "users_products.username"]
     attributes :primary => [:title, :description]
 
@@ -52,6 +52,8 @@ class Product < ActiveRecord::Base
     if DATABASE == "postgres"
       options :title, :dictionary => "english"
     end
+
+    type :aggregated_column, :float
   end
 
   search_scope :user_search do


### PR DESCRIPTION
the type attribute allows to specify columns that don't exist yet but will be created (calculated/by aggregation). Otherwise it's not possible to search for those.

example: ```type :aggregated_column, :float```