### PR TITLE
Search method is only defined for specific model

### DIFF
--- a/lib/search_cop.rb
+++ b/lib/search_cop.rb
@@ -41,8 +41,8 @@ module SearchCop
       search_scopes[name] = SearchScope.new(name, self)
       search_scopes[name].instance_exec(&block)
 
-      self.class.send(:define_method, name) { |query| search_cop query, name }
-      self.class.send(:define_method, "unsafe_#{name}") { |query| unsafe_search_cop query, name }
+      self.send(:define_singleton_method, name) { |query| search_cop query, name }
+      self.send(:define_singleton_method, "unsafe_#{name}") { |query| unsafe_search_cop query, name }
     end
 
     def search_reflection(scope_name)

--- a/test/search_cop_test.rb
+++ b/test/search_cop_test.rb
@@ -131,5 +131,10 @@ class SearchCopTest < SearchCop::TestCase
   def test_blank
     assert_equal Product.all, Product.search("")
   end
+
+  def test_not_adding_search_to_object
+    Product
+    assert_equal false, Object.respond_to?(:search)
+  end
 end
 


### PR DESCRIPTION
I found an issue that if any model in my project has search_cop search method defined then after calling it's class all my models respond_to? :search returns true.

Example:
```
class Product
  include SearchCop|
  search_scope :search do
  end
end
```

Now I call this:
```
Object.respond_to? :search
=> false
Product
Object.respond_to? :search
=> true
```

I hope my explanation is understandable :).
