### PR TITLE
Support providing arbitrary SQL query generators

### DIFF
--- a/lib/search_cop/hash_parser.rb
+++ b/lib/search_cop/hash_parser.rb
@@ -31,9 +31,13 @@ class SearchCop::HashParser
     collection = SearchCopGrammar::Attributes::Collection.new(query_info, key.to_s)
 
     if value.is_a?(Hash)
-      raise(SearchCop::ParseError, "Unknown operator #{value.keys.first}") unless [:matches, :eq, :not_eq, :gt, :gteq, :lt, :lteq].include?(value.keys.first)
+      raise(SearchCop::ParseError, "Unknown operator #{value.keys.first}") unless collection.valid_operator?(value.keys.first)
 
-      collection.send value.keys.first, value.values.first.to_s
+      if generator = collection.generator_for(value.keys.first)
+        collection.generator generator, value.values.first
+      else
+        collection.send value.keys.first, value.values.first.to_s
+      end
     else
       collection.send :matches, value.to_s
     end

--- a/lib/search_cop/search_scope.rb
+++ b/lib/search_cop/search_scope.rb
@@ -1,12 +1,13 @@
 
 module SearchCop
   class Reflection
-    attr_accessor :attributes, :options, :aliases, :scope
+    attr_accessor :attributes, :options, :aliases, :scope, :generators
 
     def initialize
       self.attributes = {}
       self.options = {}
       self.aliases = {}
+      self.generators = {}
     end
 
     def default_attributes
@@ -44,6 +45,10 @@ module SearchCop
 
     def scope(&block)
       reflection.scope = block
+    end
+
+    def generator(name, &block)
+      reflection.generators[name] = block
     end
 
     private

--- a/lib/search_cop/visitors/visitor.rb
+++ b/lib/search_cop/visitors/visitor.rb
@@ -55,6 +55,10 @@ module SearchCop
         "NOT (#{visit node.object})"
       end
 
+      def visit_SearchCopGrammar_Nodes_Generator(node)
+        instance_exec visit(node.left), node.right[:value], &node.right[:generator]
+      end
+
       def quote_table_name(name)
         connection.quote_table_name name
       end

--- a/lib/search_cop_grammar/nodes.rb
+++ b/lib/search_cop_grammar/nodes.rb
@@ -73,6 +73,7 @@ module SearchCopGrammar
     class LessThan < Binary; end
     class LessThanOrEqual < Binary; end
     class Matches < Binary; end
+    class Generator < Binary; end
 
     class Not
       include Base

--- a/test/hash_test.rb
+++ b/test/hash_test.rb
@@ -93,5 +93,15 @@ class HashTest < SearchCop::TestCase
     assert_includes results, expected
     refute_includes results, rejected
   end
+
+  def test_custom_matcher
+    expected = create(:product, :title => "Expected")
+    rejected = create(:product, :title => "Rejected")
+
+    results = Product.search(:title => { :custom_eq => "Expected" })
+
+    assert_includes results, expected
+    refute_includes results, rejected
+  end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,6 +52,10 @@ class Product < ActiveRecord::Base
     if DATABASE == "postgres"
       options :title, :dictionary => "english"
     end
+
+    generator :custom_eq do |column_name, raw_value|
+      "#{column_name} = #{quote raw_value}"
+    end
   end
 
   search_scope :user_search do


### PR DESCRIPTION
This commit provides an extension point in the `search_scope` definition that
allows you to define a named `generator` that can be used with the hash
structure to perform arbitrary SQL queries.

This allows people to query for any DB types or operators that aren't directly
supported in SearchCop, and SearchCop doesn't have to support them.

Related to #14, #28 and #31.