### PR TITLE
added alias for visit_Integer to support ruby 2.4

### DIFF
--- a/lib/search_cop/visitors/visitor.rb
+++ b/lib/search_cop/visitors/visitor.rb
@@ -94,6 +94,7 @@ module SearchCop
       alias :visit_Float :quote
       alias :visit_Fixnum :quote
       alias :visit_Symbol :quote
+      alias :visit_Integer :quote
     end
   end
 end


### PR DESCRIPTION
I just added 2.4.1 to .travis.yml and saw the commit to fix for `visit_Integer`.