### PR TITLE
allow searching for relative dates, like hours, days, weeks, months o…

### DIFF
--- a/lib/search_cop_grammar/attributes.rb
+++ b/lib/search_cop_grammar/attributes.rb
@@ -198,7 +198,11 @@ module SearchCopGrammar
       def parse(value)
         return value .. value unless value.is_a?(::String)
 
-        if value =~ /^[0-9]{4}$/
+        if value =~ /^[0-9]+ (hour|day|week|month|year)s{0,1} (ago)$/
+          number,period,ago = value.split(' ')
+          time = number.to_i.send(period.to_sym).send(ago.to_sym)
+          time .. ::Time.now
+        elsif value =~ /^[0-9]{4}$/
           ::Time.new(value).beginning_of_year .. ::Time.new(value).end_of_year
         elsif value =~ /^([0-9]{4})(\.|-|\/)([0-9]{1,2})$/
           ::Time.new($1, $3, 15).beginning_of_month .. ::Time.new($1, $3, 15).end_of_month
@@ -244,7 +248,11 @@ module SearchCopGrammar
       def parse(value)
         return value .. value unless value.is_a?(::String)
 
-        if value =~ /^[0-9]{4}$/
+        if value =~ /^[0-9]+ (day|week|month|year)s{0,1} (ago)$/
+          number,period,ago = value.split(' ')
+          time = number.to_i.send(period.to_sym).send(ago.to_sym)
+          time.to_date .. ::Date.today
+        elsif value =~ /^[0-9]{4}$/
           ::Date.new(value.to_i).beginning_of_year .. ::Date.new(value.to_i).end_of_year
         elsif value =~ /^([0-9]{4})(\.|-|\/)([0-9]{1,2})$/
           ::Date.new($1.to_i, $3.to_i, 15).beginning_of_month .. ::Date.new($1.to_i, $3.to_i, 15).end_of_month

--- a/test/date_test.rb
+++ b/test/date_test.rb
@@ -66,6 +66,34 @@ class DateTest < SearchCop::TestCase
     refute_includes Product.search("created_on <= 2014-05-01"), product
   end
 
+  def test_days_ago
+    product = create(:product, :created_at => 2.days.ago.to_date)
+
+    assert_includes Product.search("created_at <= '1 day ago'"), product
+    refute_includes Product.search("created_at <= '3 days ago'"), product
+  end
+
+  def test_weeks_ago
+    product = create(:product, :created_at => 2.weeks.ago.to_date)
+
+    assert_includes Product.search("created_at <= '1 weeks ago'"), product
+    refute_includes Product.search("created_at <= '3 weeks ago'"), product
+  end
+
+  def test_months_ago
+    product = create(:product, :created_at => 2.months.ago.to_date)
+
+    assert_includes Product.search("created_at <= '1 months ago'"), product
+    refute_includes Product.search("created_at <= '3 months ago'"), product
+  end
+
+  def test_years_ago
+    product = create(:product, :created_at => 2.years.ago.to_date)
+
+    assert_includes Product.search("created_at <= '1 years ago'"), product
+    refute_includes Product.search("created_at <= '3 years ago'"), product
+  end
+
   def test_no_overflow
     assert_nothing_raised do
       Product.search("created_on: 1000000").to_a

--- a/test/datetime_test.rb
+++ b/test/datetime_test.rb
@@ -67,6 +67,41 @@ class DatetimeTest < SearchCop::TestCase
     refute_includes Product.search("created_at <= 2014-05-01"), product
   end
 
+  def test_hours_ago
+    product = create(:product, :created_at => 5.hours.ago)
+
+    assert_includes Product.search("created_at <= '4 hours ago'"), product
+    refute_includes Product.search("created_at <= '6 hours ago'"), product
+  end
+
+  def test_days_ago
+    product = create(:product, :created_at => 2.days.ago)
+
+    assert_includes Product.search("created_at <= '1 day ago'"), product
+    refute_includes Product.search("created_at <= '3 days ago'"), product
+  end
+
+  def test_weeks_ago
+    product = create(:product, :created_at => 2.weeks.ago)
+
+    assert_includes Product.search("created_at <= '1 weeks ago'"), product
+    refute_includes Product.search("created_at <= '3 weeks ago'"), product
+  end
+
+  def test_months_ago
+    product = create(:product, :created_at => 2.months.ago)
+
+    assert_includes Product.search("created_at <= '1 months ago'"), product
+    refute_includes Product.search("created_at <= '3 months ago'"), product
+  end
+
+  def test_years_ago
+    product = create(:product, :created_at => 2.years.ago)
+
+    assert_includes Product.search("created_at <= '1 years ago'"), product
+    refute_includes Product.search("created_at <= '3 years ago'"), product
+  end
+
   def test_no_overflow
     assert_nothing_raised do
       Product.search("created_at: 1000000").to_a


### PR DESCRIPTION
This pull request allow searching for relative dates, for example
Product.search("created_at <= '1 day ago'")

This can be really useful for allowing users to save searches, and make them show the products sold last week, ...

having a saved report or something similar