### PR TITLE
Use [:blank:] instead of \s for space

### DIFF
--- a/lib/search_cop_grammar.treetop
+++ b/lib/search_cop_grammar.treetop
@@ -37,7 +37,7 @@ grammar SearchCopGrammar
   end
 
   rule anywhere_expression
-    "'" [^\']* "'" <SingleQuotedAnywhereExpression> / '"' [^\"]* '"' <DoubleQuotedAnywhereExpression> / [^\s()]+ <AnywhereExpression>
+    "'" [^\']* "'" <SingleQuotedAnywhereExpression> / '"' [^\"]* '"' <DoubleQuotedAnywhereExpression> / [^[:blank:]()]+ <AnywhereExpression>
   end
 
   rule simple_column
@@ -45,11 +45,11 @@ grammar SearchCopGrammar
   end
 
   rule value
-    "'" [^\']* "'" <SingleQuotedValue> / '"' [^\"]* '"' <DoubleQuotedValue> / [^\s()]+ <Value>
+    "'" [^\']* "'" <SingleQuotedValue> / '"' [^\"]* '"' <DoubleQuotedValue> / [^[:blank:]()]+ <Value>
   end
 
   rule space
-    [\s]+
+    [[:blank:]]+
   end
 end
 


### PR DESCRIPTION
```ruby
class Book < ActiveRecord::Base
  include SearchCop

  search_scope :search do
    attributes :title
  end

end

Book.search("Harry Potter")
```

This works as follows.

```sql
WHERE books.title LIKE '%Harry%' OR books.title LIKE '%Potter%'
```

I expected same result to this argument. (separated by double-byte space)

```ruby
Book.search("Harry　Potter")
```
But, this actually works as follows.

```sql
WHERE books.title LIKE '%Harry　Potter%'
```

I fixed it.