### PR TITLE
Updated SearchCop::Visitors::Visitor to check the connection's adapter_name when extending.

### DIFF
--- a/lib/search_cop/visitors/visitor.rb
+++ b/lib/search_cop/visitors/visitor.rb
@@ -7,8 +7,8 @@ module SearchCop
       def initialize(connection)
         @connection = connection
 
-        extend(SearchCop::Visitors::Mysql) if @connection.class.name =~ /mysql/i
-        extend(SearchCop::Visitors::Postgres) if @connection.class.name =~ /postgres/i
+        extend(SearchCop::Visitors::Mysql) if @connection.adapter_name =~ /mysql/i
+        extend(SearchCop::Visitors::Postgres) if @connection.adapter_name =~ /postgres/i
       end
 
       def visit(visit_node = node)


### PR DESCRIPTION
Hi,

I ran into an issue when using [octopus](https://github.com/thiagopradi/octopus) + search_cop.

Octopus creates a proxy class to hook into AR it's class is `Octopus::Proxy`. By using [adapter_name](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/AbstractAdapter.html#method-i-adapter_name), we can get around this issue.

```
irb(main):047:0> ActiveRecord::Base.connection.class.name
=> "Octopus::Proxy"
irb(main):048:0> ActiveRecord::Base.connection.adapter_name
=> "PostgreSQL"
```

Thanks!