### PR TITLE
Adds customizable default operator to concatenate conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,37 @@ User.search("admin")
 # ... WHERE users.username LIKE 'admin%'
 ```
 
+## Default operator
+
+When you define multiple fields on a search scope, the SearcCop will use 
+by default the AND operator to concatenate the conditions, E.g:
+
+```ruby
+class User < ActiveRecord::Base
+  include SearchCop
+
+  search_scope :search do
+    attributes :username, :fullname
+  end
+
+  # ...
+```
+
+So a search like this: `User.search("something")` will render the query 
+with the following conditions:
+```sql
+WHERE `username` LIKE '%something%' AND `fullname` LIKE '%something%'
+```
+
+There are cases where using the AND by default will lead to not being 
+able to get results, so this way SearchCop allows you to override the
+default operator to use the OR.
+So a query like `User.search("something", :default_operator: :or)` will
+generate the query using OR to concatenate the conditions
+```sql
+WHERE `username` LIKE '%something%' OR `fullname` LIKE '%something%'
+```
+
 ## Associations
 
 If you specify searchable attributes from another model, like

--- a/lib/search_cop.rb
+++ b/lib/search_cop.rb
@@ -10,6 +10,7 @@ require "search_cop/visitors"
 module SearchCop
   class SpecificationError < StandardError; end
   class UnknownAttribute < SpecificationError; end
+  class UnknownDefaultOperator < SpecificationError; end
 
   class RuntimeError < StandardError; end
   class UnknownColumn < RuntimeError; end
@@ -64,6 +65,23 @@ module SearchCop
       scope ||= eager_load(query_builder.associations) if query_builder.associations.any?
 
       (scope || self).where(query_builder.sql)
+    end
+  end
+
+  module Helpers
+    def self.sanitize_default_operator(hash, delete_hash_option=false)
+      default_operator = :and
+      if hash.member?(:default_operator)
+        unless [:and, :or].include?(hash[:default_operator])
+          raise(SearchCop::UnknownDefaultOperator, "Unknown default operator value #{hash[:default_operator]}")
+        end
+
+        default_operator = hash[:default_operator]
+      end
+
+      hash.delete(:default_operator) if delete_hash_option
+
+      default_operator
     end
   end
 end

--- a/lib/search_cop/grammar_parser.rb
+++ b/lib/search_cop/grammar_parser.rb
@@ -12,9 +12,10 @@ module SearchCop
       @query_info = query_info
     end
 
-    def parse(string)
+    def parse(string, query_options = {})
       node = SearchCopGrammarParser.new.parse(string) || raise(ParseError)
       node.query_info = query_info
+      node.query_options = query_options
       node.evaluate
     end
   end

--- a/lib/search_cop/grammar_parser.rb
+++ b/lib/search_cop/grammar_parser.rb
@@ -12,7 +12,7 @@ module SearchCop
       @query_info = query_info
     end
 
-    def parse(string, query_options = {})
+    def parse(string, query_options)
       node = SearchCopGrammarParser.new.parse(string) || raise(ParseError)
       node.query_info = query_info
       node.query_options = query_options

--- a/lib/search_cop/hash_parser.rb
+++ b/lib/search_cop/hash_parser.rb
@@ -7,13 +7,7 @@ class SearchCop::HashParser
   end
 
   def parse(hash)
-    default_operator = :and
-    if hash.member?(:default_operator)
-      raise(SearchCop::UnknownAttribute, "Unknown default operator value #{hash[:default_operator]}") unless [:and, :or].include?(hash[:default_operator])
-
-      default_operator = hash[:default_operator]
-      hash.delete(:default_operator)
-    end
+    default_operator = SearchCop::Helpers.sanitize_default_operator(hash, true)
 
     res = hash.collect do |key, value|
       case key

--- a/lib/search_cop/hash_parser.rb
+++ b/lib/search_cop/hash_parser.rb
@@ -7,6 +7,14 @@ class SearchCop::HashParser
   end
 
   def parse(hash)
+    default_operator = :and
+    if hash.member?(:default_operator)
+      raise(SearchCop::UnknownAttribute, "Unknown default operator value #{hash[:default_operator]}") unless [:and, :or].include?(hash[:default_operator])
+
+      default_operator = hash[:default_operator]
+      hash.delete(:default_operator)
+    end
+
     res = hash.collect do |key, value|
       case key
         when :and
@@ -22,7 +30,7 @@ class SearchCop::HashParser
       end
     end
 
-    res.inject :and
+    res.inject default_operator
   end
 
   private

--- a/lib/search_cop/query_builder.rb
+++ b/lib/search_cop/query_builder.rb
@@ -3,11 +3,11 @@ module SearchCop
   class QueryBuilder
     attr_accessor :query_info, :scope, :sql
 
-    def initialize(model, query, scope)
+    def initialize(model, query, scope, query_options)
       self.scope = scope
       self.query_info = QueryInfo.new(model, scope)
 
-      arel = SearchCop::Parser.parse(query, query_info).optimize!
+      arel = SearchCop::Parser.parse(query, query_info, query_options).optimize!
 
       self.sql = SearchCop::Visitors::Visitor.new(model.connection).visit(arel)
     end

--- a/lib/search_cop/search_scope.rb
+++ b/lib/search_cop/search_scope.rb
@@ -1,14 +1,13 @@
 
 module SearchCop
   class Reflection
-    attr_accessor :attributes, :options, :aliases, :scope, :generators, :default_operator
+    attr_accessor :attributes, :options, :aliases, :scope, :generators
 
     def initialize
       self.attributes = {}
       self.options = {}
       self.aliases = {}
       self.generators = {}
-      self.default_operator = :and
     end
 
     def default_attributes
@@ -36,10 +35,6 @@ module SearchCop
 
     def options(key, options = {})
       reflection.options[key.to_s] = (reflection.options[key.to_s] || {}).merge(options)
-    end
-
-    def default_operator(operator)
-      reflection.default_operator = operator.is_a?(Symbol) && [:and, :or].include?(operator) ? operator : :and
     end
 
     def aliases(hash)

--- a/lib/search_cop/search_scope.rb
+++ b/lib/search_cop/search_scope.rb
@@ -39,7 +39,7 @@ module SearchCop
     end
 
     def default_operator(operator)
-      reflection.default_operator = operator.is_a?(Symbol) ? operator : :and
+      reflection.default_operator = operator.is_a?(Symbol) && [:and, :or].include?(operator) ? operator : :and
     end
 
     def aliases(hash)

--- a/lib/search_cop/search_scope.rb
+++ b/lib/search_cop/search_scope.rb
@@ -1,13 +1,14 @@
 
 module SearchCop
   class Reflection
-    attr_accessor :attributes, :options, :aliases, :scope, :generators
+    attr_accessor :attributes, :options, :aliases, :scope, :generators, :default_operator
 
     def initialize
       self.attributes = {}
       self.options = {}
       self.aliases = {}
       self.generators = {}
+      self.default_operator = :and
     end
 
     def default_attributes
@@ -35,6 +36,10 @@ module SearchCop
 
     def options(key, options = {})
       reflection.options[key.to_s] = (reflection.options[key.to_s] || {}).merge(options)
+    end
+
+    def default_operator(operator)
+      reflection.default_operator = operator.is_a?(Symbol) ? operator : :and
     end
 
     def aliases(hash)

--- a/lib/search_cop_grammar.rb
+++ b/lib/search_cop_grammar.rb
@@ -117,7 +117,9 @@ module SearchCopGrammar
   class AndOrExpression < BaseNode
     def evaluate
       default_operator = :and
-      if query_options.member?(:default_operator) && [:and, :or].include?(query_options[:default_operator])
+      if query_options.member?(:default_operator)
+        raise(SearchCop::UnknownAttribute, "Unknown default operator value #{query_options[:default_operator]}") unless [:and, :or].include?(query_options[:default_operator])
+
         default_operator = query_options[:default_operator]
       end
       [elements.first.evaluate, elements.last.evaluate].inject(default_operator)

--- a/lib/search_cop_grammar.rb
+++ b/lib/search_cop_grammar.rb
@@ -4,10 +4,14 @@ require "search_cop_grammar/nodes"
 
 module SearchCopGrammar
   class BaseNode < Treetop::Runtime::SyntaxNode
-    attr_writer :query_info
+    attr_writer :query_info, :query_options
 
     def query_info
       (@query_info ||= nil) || parent.query_info
+    end
+
+    def query_options
+      (@query_options ||= nil) || parent.query_options
     end
 
     def evaluate
@@ -112,8 +116,11 @@ module SearchCopGrammar
 
   class AndOrExpression < BaseNode
     def evaluate
-      [elements.first.evaluate, elements.last.evaluate]
-        .inject(query_info.scope.reflection.default_operator)
+      default_operator = :and
+      if query_options.member?(:default_operator) && [:and, :or].include?(query_options[:default_operator])
+        default_operator = query_options[:default_operator]
+      end
+      [elements.first.evaluate, elements.last.evaluate].inject(default_operator)
     end
   end
 

--- a/lib/search_cop_grammar.rb
+++ b/lib/search_cop_grammar.rb
@@ -110,6 +110,13 @@ module SearchCopGrammar
     end
   end
 
+  class AndOrExpression < BaseNode
+    def evaluate
+      [elements.first.evaluate, elements.last.evaluate]
+        .inject(query_info.scope.reflection.default_operator)
+    end
+  end
+
   class OrExpression < BaseNode
     def evaluate
       [elements.first.evaluate, elements.last.evaluate].inject(:or)

--- a/lib/search_cop_grammar.rb
+++ b/lib/search_cop_grammar.rb
@@ -116,12 +116,7 @@ module SearchCopGrammar
 
   class AndOrExpression < BaseNode
     def evaluate
-      default_operator = :and
-      if query_options.member?(:default_operator)
-        raise(SearchCop::UnknownAttribute, "Unknown default operator value #{query_options[:default_operator]}") unless [:and, :or].include?(query_options[:default_operator])
-
-        default_operator = query_options[:default_operator]
-      end
+      default_operator = SearchCop::Helpers.sanitize_default_operator(query_options)
       [elements.first.evaluate, elements.last.evaluate].inject(default_operator)
     end
   end

--- a/lib/search_cop_grammar.treetop
+++ b/lib/search_cop_grammar.treetop
@@ -9,7 +9,9 @@ grammar SearchCopGrammar
   end
 
   rule and_expression
-    or_expression (space? ('AND' / 'and') space? / space !('OR' / 'or')) complex_expression <AndOrExpression> / or_expression
+    or_expression space? ('AND' / 'and') space? complex_expression <AndExpression> /
+    or_expression space !('OR' / 'or') complex_expression <AndOrExpression> /
+    or_expression
   end
 
   rule or_expression

--- a/lib/search_cop_grammar.treetop
+++ b/lib/search_cop_grammar.treetop
@@ -9,7 +9,7 @@ grammar SearchCopGrammar
   end
 
   rule and_expression
-    or_expression (space? ('AND' / 'and') space? / space !('OR' / 'or')) complex_expression <AndExpression> / or_expression
+    or_expression (space? ('AND' / 'and') space? / space !('OR' / 'or')) complex_expression <AndOrExpression> / or_expression
   end
 
   rule or_expression

--- a/test/default_operator_test.rb
+++ b/test/default_operator_test.rb
@@ -1,10 +1,10 @@
-require File.expand_path("../test_helper", __FILE__)
+require File.expand_path('../test_helper', __FILE__)
 
 class DefaultOperatorTest < SearchCop::TestCase
 
   def test_without_default_operator
-    avengers = create(:product, title: "Title Avengers")
-    inception = create(:product, title: "Title Inception")
+    avengers = create(:product, title: "Title Avengers", description: "2012")
+    inception = create(:product, title: "Title Inception", description: "2010")
 
     results = Product.search_multi_columns("Title Avengers")
     assert_includes results, avengers
@@ -17,14 +17,31 @@ class DefaultOperatorTest < SearchCop::TestCase
     results = Product.search_multi_columns("Title OR Avengers")
     assert_includes results, avengers
     assert_includes results, inception
+
+    results = Product.search(title: "Avengers", description: "2012")
+    assert_includes results, avengers
+    refute_includes results, inception
   end
 
   def test_with_specific_default_operator
-    matrix = create(:product, title: "Matrix")
-    start_wars = create(:product, title: "Start Wars")
+    matrix = create(:product, title: "Matrix", description: "1999 Fantasy Sci-fi 2h 30m")
+    start_wars = create(:product, title: "Start Wars", description: "2010 Sci-fi Thriller 2h 28m")
 
     results = Product.search_multi_columns("Matrix movie", default_operator: :or)
     assert_includes results, matrix
     refute_includes results, start_wars
+
+    results = Product.search(title: "Matrix", description: "2000", default_operator: :or)
+    assert_includes results, matrix
+    refute_includes results, start_wars
+  end
+
+  def test_with_invalid_default_operator
+    assert_raises SearchCop::UnknownAttribute do
+      Product.search_multi_columns('Matrix movie', default_operator: :xpto)
+    end
+    assert_raises SearchCop::UnknownAttribute do
+      Product.search_multi_columns(title: 'Matrix movie', default_operator: :xpto)
+    end
   end
 end

--- a/test/default_operator_test.rb
+++ b/test/default_operator_test.rb
@@ -1,0 +1,25 @@
+require File.expand_path("../test_helper", __FILE__)
+
+class DefaultOperatorTest < SearchCop::TestCase
+
+  def test_default_operator_and
+    expected = create(:product, :title => "Title Avengers")
+    rejected = create(:product, :title => "Title Inception")
+
+    results = Product.search_with_and_operator("Title Avengers")
+
+    assert_includes results, expected
+    refute_includes results, rejected
+  end
+
+  def test_default_operator_or
+    expected = create(:product, :title => "Title Avengers")
+    rejected = create(:product, :title => "Title Inception")
+
+    results = Product.search_with_or_operator("Movie Avengers")
+
+    assert_includes results, expected
+    refute_includes results, rejected
+  end
+
+end

--- a/test/default_operator_test.rb
+++ b/test/default_operator_test.rb
@@ -37,10 +37,10 @@ class DefaultOperatorTest < SearchCop::TestCase
   end
 
   def test_with_invalid_default_operator
-    assert_raises SearchCop::UnknownAttribute do
+    assert_raises SearchCop::UnknownDefaultOperator do
       Product.search_multi_columns('Matrix movie', default_operator: :xpto)
     end
-    assert_raises SearchCop::UnknownAttribute do
+    assert_raises SearchCop::UnknownDefaultOperator do
       Product.search_multi_columns(title: 'Matrix movie', default_operator: :xpto)
     end
   end

--- a/test/default_operator_test.rb
+++ b/test/default_operator_test.rb
@@ -2,24 +2,29 @@ require File.expand_path("../test_helper", __FILE__)
 
 class DefaultOperatorTest < SearchCop::TestCase
 
-  def test_default_operator_and
-    expected = create(:product, :title => "Title Avengers")
-    rejected = create(:product, :title => "Title Inception")
+  def test_without_default_operator
+    avengers = create(:product, :title => "Title Avengers")
+    inception = create(:product, :title => "Title Inception")
 
-    results = Product.search_with_and_operator("Title Avengers")
+    results = Product.search_multi_columns("Title Avengers")
+    assert_includes results, avengers
+    refute_includes results, inception
 
-    assert_includes results, expected
-    refute_includes results, rejected
+    results = Product.search_multi_columns("Title AND Avengers")
+    assert_includes results, avengers
+    refute_includes results, inception
+
+    results = Product.search_multi_columns("Title OR Avengers")
+    assert_includes results, avengers
+    assert_includes results, inception
   end
 
-  def test_default_operator_or
-    expected = create(:product, :title => "Title Avengers")
-    rejected = create(:product, :title => "Title Inception")
+  def test_with_specific_default_operator
+    matrix = create(:product, :title => "Matrix")
+    start_wars = create(:product, :title => "Start Wars")
 
-    results = Product.search_with_or_operator("Movie Avengers")
-
-    assert_includes results, expected
-    refute_includes results, rejected
+    results = Product.search_multi_columns("Matrix movie", default_operator: :or)
+    assert_includes results, matrix
+    refute_includes results, start_wars
   end
-
 end

--- a/test/default_operator_test.rb
+++ b/test/default_operator_test.rb
@@ -3,8 +3,8 @@ require File.expand_path("../test_helper", __FILE__)
 class DefaultOperatorTest < SearchCop::TestCase
 
   def test_without_default_operator
-    avengers = create(:product, :title => "Title Avengers")
-    inception = create(:product, :title => "Title Inception")
+    avengers = create(:product, title: "Title Avengers")
+    inception = create(:product, title: "Title Inception")
 
     results = Product.search_multi_columns("Title Avengers")
     assert_includes results, avengers
@@ -20,8 +20,8 @@ class DefaultOperatorTest < SearchCop::TestCase
   end
 
   def test_with_specific_default_operator
-    matrix = create(:product, :title => "Matrix")
-    start_wars = create(:product, :title => "Start Wars")
+    matrix = create(:product, title: "Matrix")
+    start_wars = create(:product, title: "Start Wars")
 
     results = Product.search_multi_columns("Matrix movie", default_operator: :or)
     assert_includes results, matrix

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,6 +68,16 @@ class Product < ActiveRecord::Base
     aliases :users_products => User
   end
 
+  search_scope :search_with_and_operator do
+    attributes all: [:title, :description]
+    default_operator :and
+  end
+
+  search_scope :search_with_or_operator do
+    attributes all: [:title, :description]
+    default_operator :or
+  end
+
   has_many :comments
   has_many :users, :through => :comments
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,14 +68,8 @@ class Product < ActiveRecord::Base
     aliases :users_products => User
   end
 
-  search_scope :search_with_and_operator do
+  search_scope :search_multi_columns do
     attributes all: [:title, :description]
-    default_operator :and
-  end
-
-  search_scope :search_with_or_operator do
-    attributes all: [:title, :description]
-    default_operator :or
   end
 
   has_many :comments


### PR DESCRIPTION
Based on the issue #48.
This PR adds an option to define the default operator to join the conditions.

By default multiple conditions on `where` are joined with `AND` operator and this new option allows to define to operator (`AND` or `OR`) to join the multiple conditions