### PR TITLE
Fixed to work with inherited models

### DIFF
--- a/lib/search_cop/query_builder.rb
+++ b/lib/search_cop/query_builder.rb
@@ -12,7 +12,7 @@ module SearchCop
     end
 
     def associations
-      all_associations - [query_info.model.name.tableize.to_sym]
+      all_associations - [query_info.model.table_name.to_sym]
     end
 
     private

--- a/test/search_cop_test.rb
+++ b/test/search_cop_test.rb
@@ -61,6 +61,15 @@ class SearchCopTest < SearchCop::TestCase
     refute_includes results, rejected
   end
 
+  def test_inherited_model
+    expected = create(:available_product, comments: [create(:comment, user: create(:user, username: "Expected"))])
+    rejected = create(:available_product, comments: [create(:comment, user: create(:user, username: "Rejected"))])
+
+    results = AvailableProduct.search("user: Expected")
+    assert_includes results, expected
+    refute_includes results, rejected
+  end
+
   def test_multiple
     product = create(:product, comments: [create(:comment, title: "Title", message: "Message")])
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,8 +77,16 @@ class Product < ActiveRecord::Base
   belongs_to :user
 end
 
+class AvailableProduct < Product
+  default_scope { where(available: true) }
+end
+
 FactoryBot.define do
   factory :product do
+  end
+
+  factory :available_product do
+    available { true }
   end
 
   factory :comment do


### PR DESCRIPTION
In my case, when used with ActiveType, the model name cannot be handled correctly.

```ruby
class User < ApplicationRecord
  include SearchCop

  search_scope :search do
    ...
  end
end

class Admin::User < ActiveType::Record[User]; end

Admin::User.search # looks table as admin/users
```

In the general case, even if you inherit the model, the model name cannot be handled correctly.

```ruby
class Admin < User; end

Admin.search # looks table as admin
```

So I changed it to get the table name from Model.table_name.