### PR TITLE
Timestamptz support

### DIFF
--- a/lib/search_cop/visitors/visitor.rb
+++ b/lib/search_cop/visitors/visitor.rb
@@ -79,6 +79,7 @@ module SearchCop
       alias :visit_SearchCopGrammar_Attributes_Decimal :visit_attribute
       alias :visit_SearchCopGrammar_Attributes_Datetime :visit_attribute
       alias :visit_SearchCopGrammar_Attributes_Timestamp :visit_attribute
+      alias :visit_SearchCopGrammar_Attributes_Timestamptz :visit_attribute
       alias :visit_SearchCopGrammar_Attributes_Date :visit_attribute
       alias :visit_SearchCopGrammar_Attributes_Time :visit_attribute
       alias :visit_SearchCopGrammar_Attributes_Boolean :visit_attribute

--- a/lib/search_cop_grammar/attributes.rb
+++ b/lib/search_cop_grammar/attributes.rb
@@ -255,6 +255,7 @@ module SearchCopGrammar
     end
 
     class Timestamp < Datetime; end
+    class Timestamptz < Datetime; end
 
     class Date < Datetime
       def parse(value)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,6 +49,8 @@ class Product < ActiveRecord::Base
     end
 
     if DATABASE == "postgres"
+      attributes :restocked_at
+
       options :title, dictionary: "english"
     end
 
@@ -128,6 +130,10 @@ ActiveRecord::Base.connection.create_table :products do |t|
   t.boolean :available
   t.string :brand
   t.string :notice
+
+  if DATABASE == "postgres"
+    t.timestamptz :restocked_at
+  end
 end
 
 ActiveRecord::Base.connection.create_table :posts do |t|


### PR DESCRIPTION
Postgres supports the `timestamp with timezone` column. Searching that type of column currently produces:

```
NameError: uninitialized constant SearchCopGrammar::Attributes::Timestamptz
    lib/search_cop_grammar/attributes.rb:96:in `attribute_for'
    lib/search_cop_grammar/attributes.rb:62:in `block in attributes'
```

This patch merely adds the type's class under `Attributes` and visitor, which seems to fix the problem.