### PR TITLE
Add tests for inequality with relative times

### DIFF
--- a/test/datetime_test.rb
+++ b/test/datetime_test.rb
@@ -66,39 +66,151 @@ class DatetimeTest < SearchCop::TestCase
     refute_includes Product.search("created_at <= 2014-05-01"), product
   end
 
-  def test_hours_ago
+  def test_hours_ago_less
+    product = create(:product, created_at: 5.hours.ago)
+
+    assert_includes Product.search("created_at < '4 hours ago'"), product
+    refute_includes Product.search("created_at < '6 hours ago'"), product
+  end
+
+  def test_hours_ago_less
+    product = create(:product, created_at: 5.hours.ago)
+
+    assert_includes Product.search("created_at < '4 hours ago'"), product
+    refute_includes Product.search("created_at < '6 hours ago'"), product
+  end
+
+  def test_hours_ago_less_equals
     product = create(:product, created_at: 5.hours.ago)
 
     assert_includes Product.search("created_at <= '4 hours ago'"), product
     refute_includes Product.search("created_at <= '6 hours ago'"), product
   end
 
-  def test_days_ago
+  def test_hours_ago_greater
+    product = create(:product, created_at: 5.hours.ago)
+
+    refute_includes Product.search("created_at > '4 hours ago'"), product
+    assert_includes Product.search("created_at > '6 hours ago'"), product
+  end
+
+  def test_hours_ago_greater_equals
+    product = create(:product, created_at: 5.hours.ago)
+
+    refute_includes Product.search("created_at >= '4 hours ago'"), product
+    assert_includes Product.search("created_at >= '6 hours ago'"), product
+  end
+
+  def test_days_ago_less
+    product = create(:product, created_at: 2.days.ago)
+
+    assert_includes Product.search("created_at < '1 day ago'"), product
+    refute_includes Product.search("created_at < '3 days ago'"), product
+  end
+
+  def test_days_ago_less_equals
     product = create(:product, created_at: 2.days.ago)
 
     assert_includes Product.search("created_at <= '1 day ago'"), product
     refute_includes Product.search("created_at <= '3 days ago'"), product
   end
 
-  def test_weeks_ago
+  def test_days_ago_greater
+    product = create(:product, created_at: 2.days.ago)
+
+    refute_includes Product.search("created_at > '1 day ago'"), product
+    assert_includes Product.search("created_at > '3 days ago'"), product
+  end
+
+  def test_days_ago_greater_equals
+    product = create(:product, created_at: 2.days.ago)
+
+    refute_includes Product.search("created_at >= '1 day ago'"), product
+    assert_includes Product.search("created_at >= '3 days ago'"), product
+  end
+
+  def test_weeks_ago_less
+    product = create(:product, created_at: 2.weeks.ago)
+
+    assert_includes Product.search("created_at < '1 weeks ago'"), product
+    refute_includes Product.search("created_at < '3 weeks ago'"), product
+  end
+
+  def test_weeks_ago_less_equals
     product = create(:product, created_at: 2.weeks.ago)
 
     assert_includes Product.search("created_at <= '1 weeks ago'"), product
     refute_includes Product.search("created_at <= '3 weeks ago'"), product
   end
 
-  def test_months_ago
+  def test_weeks_ago_greater
+    product = create(:product, created_at: 2.weeks.ago)
+
+    refute_includes Product.search("created_at > '1 weeks ago'"), product
+    assert_includes Product.search("created_at > '3 weeks ago'"), product
+  end
+
+  def test_weeks_ago_greater_equals
+    product = create(:product, created_at: 2.weeks.ago)
+
+    refute_includes Product.search("created_at >= '1 weeks ago'"), product
+    assert_includes Product.search("created_at >= '3 weeks ago'"), product
+  end
+
+  def test_months_ago_less
+    product = create(:product, created_at: 2.months.ago)
+
+    assert_includes Product.search("created_at < '1 months ago'"), product
+    refute_includes Product.search("created_at < '3 months ago'"), product
+  end
+
+  def test_months_ago_less_equals
     product = create(:product, created_at: 2.months.ago)
 
     assert_includes Product.search("created_at <= '1 months ago'"), product
     refute_includes Product.search("created_at <= '3 months ago'"), product
   end
 
-  def test_years_ago
+  def test_months_ago_greater
+    product = create(:product, created_at: 2.months.ago)
+
+    refute_includes Product.search("created_at > '1 months ago'"), product
+    assert_includes Product.search("created_at > '3 months ago'"), product
+  end
+
+  def test_months_ago_greater_equals
+    product = create(:product, created_at: 2.months.ago)
+
+    refute_includes Product.search("created_at >= '1 months ago'"), product
+    assert_includes Product.search("created_at >= '3 months ago'"), product
+  end
+
+  def test_years_ago_less
+    product = create(:product, created_at: 2.years.ago)
+
+    assert_includes Product.search("created_at < '1 years ago'"), product
+    refute_includes Product.search("created_at < '3 years ago'"), product
+  end
+
+  def test_years_ago_less_equals
     product = create(:product, created_at: 2.years.ago)
 
     assert_includes Product.search("created_at <= '1 years ago'"), product
     refute_includes Product.search("created_at <= '3 years ago'"), product
+  end
+
+  def test_years_ago_greater
+    product = create(:product, created_at: 2.years.ago)
+
+    refute_includes Product.search("created_at > '1 years ago'"), product
+    assert_includes Product.search("created_at > '3 years ago'"), product
+  end
+
+  def test_years_ago_greater_equals
+    product = create(:product, created_at: 2.years.ago)
+
+    refute_includes Product.search("created_at >= '1 years ago'"), product
+    assert_includes Product.search("created_at >= '3 years ago'"), product
   end
 
   if DATABASE == "postgres" && ActiveRecord::VERSION::MAJOR >= 7


### PR DESCRIPTION
These tests demonstrate what seems to be an issue w/ relative DateTime and `gt`.

```ruby
      def gt(value)
        super parse(value).last
      end
```
`gt` is overridden for DateTime - with relative timestamps, `last` - the end of the range will be `Time.now`, so comparing to it will fail.

`gteq`, which works, comes from a dynamic definition in `Base` class  and calls `map`:

```
      def map(value)
        parse(value).first
      end
```

So perhaps the fix would be to get rid of `gt` override? But TBH, I don't have enough context for why it was introduced in 5810dccb2a09217637ed7a2329781d6e5d481d3d and when it possibly became an issue.